### PR TITLE
fixes typo in shooting guard's test

### DIFF
--- a/spec/basic_sinatra_forms_spec.rb
+++ b/spec/basic_sinatra_forms_spec.rb
@@ -19,7 +19,7 @@ describe App do
     end
   end
 
-  describe 'POST /team' do
+  describe 'POST /newteam' do
     it "displays the basketball team name in the browser" do 
       visit '/newteam'
 
@@ -49,7 +49,7 @@ describe App do
     it "displays the shooting guard's name in the browser" do
       visit '/newteam'
 
-      fill_in(:pg, :with => "Ralph")
+      fill_in(:sg, :with => "Ralph")
       click_button "submit"
 
       expect(page).to have_text("Shooting Guard: Ralph")


### PR DESCRIPTION
There is an error in one of these tests, :pg is being filled in instead of :sg for the shooting guard test.
I've also proposed a change to the description of the POST /team to POST /newteam, as it seems to make much more sense.  I'll propose a change to the README.md to match up with this change.
I worked on this for a few minutes, had the application working as expected, but was failing tests because the instructions say to put the form on the team.erb template when the tests are expecting it to be in the newteam.erb template--which seems to make more sense because then the team.erb template will render the team name, coach and position players after they have been inputted via the form in the newteam.erb view.