### PR TITLE
specify exact version of Capybara to avoid issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'require_all'
 
 group :test do
   gem 'rspec'
-  gem 'capybara'
+  gem 'capybara', '2.17.0'
   gem 'rack-test'
   gem 'poltergeist'
 end


### PR DESCRIPTION
This change will fix an issue where <input> element of type "submit" does not work for the Capybara#click_button method. 
Without explicit statement of version 2.17.0, bundle installs version 2.18.0. This forces use of <button> element for Submit button. See issue #871 for more info. 